### PR TITLE
security: validate GitHub PoC URLs to prevent path traversal

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -816,9 +816,9 @@
                     <div class="detail-section">
                         <span class="section-label">// PoC Files</span>
                         <div class="poc-files">
-                            ${poc.nuclei?.map(f => `<a href="https://github.com/happyhackingspace/vt-templates/blob/main/${encodeURIComponent(t.category || 'cves')}/${encodeURIComponent(t.id)}/${encodeURIComponent(f)}" target="_blank" rel="noopener" class="poc-file nuclei">nuclei: ${escapeHtml(f)}</a>`).join('') || ''}
-                            ${poc.bambda?.map(f => `<a href="https://github.com/happyhackingspace/vt-templates/blob/main/${encodeURIComponent(t.category || 'cves')}/${encodeURIComponent(t.id)}/${encodeURIComponent(f)}" target="_blank" rel="noopener" class="poc-file bambda">bambda: ${escapeHtml(f)}</a>`).join('') || ''}
-                            ${poc.semgrep?.map(f => `<a href="https://github.com/happyhackingspace/vt-templates/blob/main/${encodeURIComponent(t.category || 'cves')}/${encodeURIComponent(t.id)}/${encodeURIComponent(f)}" target="_blank" rel="noopener" class="poc-file semgrep">semgrep: ${escapeHtml(f)}</a>`).join('') || ''}
+                            ${poc.nuclei?.map(f => `<a href="${buildRepoUrl(t.category, t.id, f)}" target="_blank" rel="noopener" class="poc-file nuclei">nuclei: ${escapeHtml(f)}</a>`).join('') || ''}
+                            ${poc.bambda?.map(f => `<a href="${buildRepoUrl(t.category, t.id, f)}" target="_blank" rel="noopener" class="poc-file bambda">bambda: ${escapeHtml(f)}</a>`).join('') || ''}
+                            ${poc.semgrep?.map(f => `<a href="${buildRepoUrl(t.category, t.id, f)}" target="_blank" rel="noopener" class="poc-file semgrep">semgrep: ${escapeHtml(f)}</a>`).join('') || ''}
                         </div>
                     </div>
                     ` : ''}
@@ -866,6 +866,12 @@
             `;
         }
 
+        // Configuration
+        const CONFIG = {
+            REPO_BASE_URL: 'https://github.com/happyhackingspace/vt-templates/blob/main',
+            REPO_RAW_URL: 'https://raw.githubusercontent.com/happyhackingspace/vt-templates/main'
+        };
+
         function escapeHtml(s) {
             return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
         }
@@ -876,6 +882,33 @@
 
         function isValidId(id) {
             return typeof id === 'string' && /^[a-zA-Z0-9_-]+$/.test(id) && id.length <= 50;
+        }
+
+        function isValidFilename(filename) {
+            // Allow alphanumeric, hyphen, underscore, dot (for extensions)
+            // Must not contain path traversal sequences
+            if (typeof filename !== 'string') return false;
+            if (filename.length === 0 || filename.length > 100) return false;
+            // Reject path traversal attempts
+            if (filename.includes('..') || filename.includes('/') || filename.includes('\\')) return false;
+            // Only allow safe characters
+            return /^[a-zA-Z0-9._-]+$/.test(filename);
+        }
+
+        function buildRepoUrl(category, templateId, filename) {
+            // Validate all components before building URL
+            if (!isValidId(templateId)) {
+                console.warn('Invalid template ID:', templateId);
+                return '#';
+            }
+            if (!isValidFilename(filename)) {
+                console.warn('Invalid filename:', filename);
+                return '#';
+            }
+            const safeCat = encodeURIComponent(category || 'cves');
+            const safeId = encodeURIComponent(templateId);
+            const safeFile = encodeURIComponent(filename);
+            return `${CONFIG.REPO_BASE_URL}/${safeCat}/${safeId}/${safeFile}`;
         }
 
         function highlightHttp(raw, type, highlights) {


### PR DESCRIPTION
## Summary

Fixes Unvalidated URL Redirection vulnerability in PoC file links.

## Changes

- Added CONFIG object - Centralized repository URLs for easy maintenance
- Added isValidFilename() - Validates PoC filenames (alphanumeric, dot, hyphen, underscore only)
- Added buildRepoUrl() - Safely constructs GitHub URLs with validation
- Updated PoC links - Replaced hardcoded URLs with validated function calls

## Security Improvements

| Before | After |
|--------|-------|
| Direct URL construction from template data | Validated URL building with isValidId() + isValidFilename() |
| Path traversal possible via t.id or f | .., /, \\ characters rejected |
| Hardcoded URLs in 3 places | Single CONFIG.REPO_BASE_URL constant |
| Invalid URLs generated silently | Returns # with console warning |

## Testing

- Valid template IDs: VT-2024-12345, cve-2021-44228
- Invalid IDs blocked: ../../../etc/passwd, file<script>alert(1)</script>
- Invalid filenames blocked: ..%2F..%2Fetc%2Fpasswd, file/../../../etc/hosts

## Related

- Fixes: Unvalidated URL Redirection (CONCERNS.md)